### PR TITLE
Extract some of the child element styles into mixins

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ You can then use the mixins directly in your code:
 .article-container blockquote {
 	@include oQuoteStandard;
 
+	//oQuoteStandard includes styles for a .o-quote-icon element, but without that element you can include the icon in a :before
+	&:before {
+		content: '';
+		display: block;
+		@include oQuoteStandardIcon;
+	}
+
 	cite {
 		@include oQuoteStandardCite;
 	}

--- a/src/_standard.scss
+++ b/src/_standard.scss
@@ -3,15 +3,19 @@
 /// @link http://registry.origami.ft.com/components/o-quote
 ////
 
+@mixin oQuoteStandardIcon {
+	position: absolute;
+	top: oTypographySpacingSize($units: 4);
+	left: oTypographySpacingSize($units: 2);
+	@include oIconsGetIcon('speech-left', oColorsGetPaletteColor('claret-80'), 50);
+}
+
 /// Add to container for a standard quote
 @mixin oQuoteStandard {
 	background-color: oColorsGetColorFor(o-quote, background);
 	position: relative;
 	.o-quote-icon {
-		position: absolute;
-		top: oTypographySpacingSize($units: 4);
-		left: oTypographySpacingSize($units: 2);
-		@include oIconsGetIcon('speech-left', oColorsGetPaletteColor('claret-80'), 50);
+		@include oQuoteStandardIcon;
 	}
 
 	a {
@@ -21,6 +25,16 @@
 	p {
 		color: oColorsGetColorFor(body, text);
 	}
+}
+
+@mixin oQuoteStandardCiteAuthor {
+	text-transform: uppercase;
+	display: block;
+	@include oTypographySansBold($scale: 0);
+}
+
+@mixin oQuoteStandardCiteSource {
+	display: block;
 }
 
 /// Apply this to a <cite> within a standard quote block
@@ -33,12 +47,10 @@
 		@include oTypographyLink;
 	}
 	.o-quote__author {
-		text-transform: uppercase;
-		display: block;
-		@include oTypographySansBold($scale: 0);
+		@include oQuoteStandardCiteAuthor;
 	}
 	.o-quote__source {
-		display: block;
+		@include oQuoteStandardCiteSource;
 	}
 }
 


### PR DESCRIPTION
We want to start using this on FT.com for blockquotes - however some of the blockquotes we get through won't have the elements for icons and \<spans> inside the \<cite>.

This PR attempts to extract out those styles into mixins that we can use, in a way that isn't a breaking change for existing mixin users 

(Note: We may get some duplicated styles if we, for example, include `oQuoteStandard` and `oQuoteStandardIcon` - but can't think of a way to avoid that without being a _marginally_ breaking change)