### PR TITLE
Redesign of quotes to be less shouty

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Add an `o-quote` class to any quote you wish to apply the styles to.
 
 ```html
 <blockquote class="o-quote o-quote--standard">
-	<div class="o-quote-icon"></div>
 		<p>
 			The prize for this century’s worst technology product probably belongs to Google Glass, a pair of spectacles with an inbuilt camera and a tiny lens on which you could browse the internet. Suddenly you could film everybody you met, or silently ignore them and read Wikipedia.
 		</p>
@@ -41,13 +40,6 @@ You can then use the mixins directly in your code:
 ```scss
 .article-container blockquote {
 	@include oQuoteStandard;
-
-	//oQuoteStandard includes styles for a .o-quote-icon element, but without that element you can include the icon in a :before
-	&:before {
-		content: '';
-		display: block;
-		@include oQuoteStandardIcon;
-	}
 
 	cite {
 		@include oQuoteStandardCite;

--- a/demos/src/standard.mustache
+++ b/demos/src/standard.mustache
@@ -1,5 +1,4 @@
 <blockquote class="o-quote o-quote--standard">
-	<div class="o-quote-icon"></div>
 	<p>Origami is about empowering developers of all levels to build robust, on-brand products ranging from simple static sites through to rich, dynamic web applications, to do it faster, to do it cheaper, and leave them more supportable and more maintainable.</p>
 	<cite class="o-quote__cite"><span class="o-quote__author">The Origami Spec</span><span class="o-quote__source">Financial Times</span></cite>
 </blockquote>

--- a/src/_base.scss
+++ b/src/_base.scss
@@ -20,9 +20,10 @@
 	margin: 0;
 
 	p {
-		@include oTypographySans($scale: 1);
-		@include oTypographyPadding($bottom: 3);
-		margin: 0;
+		@include oTypographyBody;
+		&:last-child {
+			@include oTypographyMargin($bottom: 0);
+		}
 	}
 }
 

--- a/src/_color-use-cases.scss
+++ b/src/_color-use-cases.scss
@@ -1,1 +1,1 @@
-@include oColorsSetUseCase(o-quote, background, 'black-5');
+@include oColorsSetUseCase(o-quote, border, 'black-90');

--- a/src/_color-use-cases.scss
+++ b/src/_color-use-cases.scss
@@ -1,1 +1,2 @@
+@include oColorsSetUseCase(o-quote, background, 'transparent');
 @include oColorsSetUseCase(o-quote, border, 'black-90');

--- a/src/_standard.scss
+++ b/src/_standard.scss
@@ -4,19 +4,18 @@
 ////
 
 @mixin oQuoteStandardIcon {
-	position: absolute;
-	top: oTypographySpacingSize($units: 4);
-	left: oTypographySpacingSize($units: 2);
-	@include oIconsGetIcon('speech-left', oColorsGetPaletteColor('claret-80'), 50, $iconset-version: 1);
+	@warn "oQuoteStandardIcon is now deprecated and will be removed in next major release";
 }
 
 /// Add to container for a standard quote
 @mixin oQuoteStandard {
-	background-color: oColorsGetColorFor(o-quote, background);
 	position: relative;
-	.o-quote-icon {
-		@include oQuoteStandardIcon;
-	}
+	border-left: 4px solid oColorsGetColorFor(o-quote, border);
+
+	padding-top: 0px;
+	padding-bottom: 0px;
+
+	padding-left: oTypographySpacingSize($units: 4);
 
 	a {
 		@include oTypographyLink;

--- a/src/_standard.scss
+++ b/src/_standard.scss
@@ -10,6 +10,7 @@
 /// Add to container for a standard quote
 @mixin oQuoteStandard {
 	position: relative;
+	background-color: oColorsGetColorFor(o-quote, background);
 	border-left: 4px solid oColorsGetColorFor(o-quote, border);
 
 	padding-top: 0px;

--- a/src/_standard.scss
+++ b/src/_standard.scss
@@ -4,7 +4,7 @@
 ////
 
 @mixin oQuoteStandardIcon {
-	@warn "oQuoteStandardIcon is now deprecated and will be removed in next major release";
+	@warn "oQuoteStandardIcon is now deprecated and will be removed in the next major release";
 }
 
 /// Add to container for a standard quote


### PR DESCRIPTION
* No more background
* No more quote icon (the mixin - which _should_ just be used by Next, now does nothing but warn. the div with class "o-quote-icon" should be empty, so now no longer has any styles).
* Typography uses body typography
* Border and padding tweaks

![screen shot 2017-08-30 at 16 27 08](https://user-images.githubusercontent.com/1978880/29881051-638fae8c-8da1-11e7-86e3-73e02d9157d7.png)
![screen shot 2017-08-30 at 16 26 55](https://user-images.githubusercontent.com/1978880/29881055-6684e3be-8da1-11e7-9dcc-ee6f32b76139.png)
