### PR TITLE
Update `o-quote--editorial` to inherit typography styles.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For a standard blockquote style use classes `o-quote o-quote--standard` and the 
 </blockquote>
 ```
 
-For an editorial style blockquote swap the `o-quote--standard` class for `o-quote--editorial`. The editorial variant is only available to master brand users.
+For an editorial style blockquote swap the `o-quote--standard` class for `o-quote--editorial`. The editorial variant inherits font size and colour to support multiple editorial contexts. For example at the time of writing [live blogs](https://www.ft.com/content/f61c179d-fd47-38ba-b1ab-df158fa62dd9) and article pages have different font sizes on large viewports but both should share the editorial quote style. Therefore the editorial quote must be within an element that sets typography styles such as [o-editorial-typography-body](https://registry.origami.ft.com/components/o-editorial-typography/readme?brand=master#body).
 ```diff
 -<blockquote class="o-quote o-quote--standard">
 +<blockquote class="o-quote o-quote--editorial">

--- a/origami.json
+++ b/origami.json
@@ -18,6 +18,7 @@
 	"demosDefaults": {
 		"sass": "demos/src/demo.scss",
 		"dependencies": [
+			"o-editorial-typography@^1.0.7",
 			"o-fonts@^4.0.0",
 			"o-normalise@^2.0.0"
 		]
@@ -36,6 +37,7 @@
 				"author": "Lorem ipsum",
 				"source": "Lorem, ipsum dolor."
 			},
+			"documentClasses": "o-editorial-typography-body",
 			"description": "A blockquote style for editorial contexts such as articles. A block quote is a passage of text from another source, or a passage of text that’s been spoken by a person. Used to attribute another source of information, or to quote the spoken words of a person.",
 			"brands": [
 				"master"

--- a/src/scss/_placeholders.scss
+++ b/src/scss/_placeholders.scss
@@ -90,13 +90,12 @@
 		}
 
 		p {
-			@include oEditorialTypographyBody();
-			// repeated margin as `oEditorialTypographyBody`
-			// outputs a margin property
-			margin-bottom: oSpacingByName('s4');
-			&:last-child {
-				margin-bottom: 0;
-			}
+			// Output editorial font family.
+			// Do not output other typography properties as these should be
+			// inherited depending on the context of the editorial blockquote.
+			// E.g. At the time of writing the font size of stories differed
+			// on article pages and live blogs by design.
+			@include oTypographySerif();
 		}
 	}
 }


### PR DESCRIPTION
The `oEditorialTypographyBody` mixin was used to set the font size
of the main editorial quote body. However the lives blogs page has
smaller typography at larger viewports than article pages, showing
body copy can differ across editorial contexts.

As the intention of `o-quote--editorial` is to match the body copy
of the context it is used we will rely on the CSS cascade instead
(mostly, we still use `oTypographySerif` to enforce an editorial
font family).

As `next-article` can not easily update article markup, that project
will need to apply blockquote styles directly in a similar way to
article body copy:
https://github.com/Financial-Times/next-article/blob/0a4aa4222162b935addebd2477bec408f34ac77c/client/components/article/_main.scss#L87

The live blogs page will just work, as body typography styles are
already set on a parent element.

And potential new users, like Spark CMS, will be able to use
`o-editorial-typography-body` classes on a parent element:
https://registry.origami.ft.com/components/o-editorial-typography/readme?brand=master#body

Issue details: https://github.com/Financial-Times/o-quote/issues/67